### PR TITLE
Add support for adding/removing arbitrary nodes from the cluster.

### DIFF
--- a/test/herd_test.exs
+++ b/test/herd_test.exs
@@ -84,6 +84,50 @@ defmodule HerdTest do
     verify_nodes_present(nodes)
   end
 
+  test "It will add a node" do
+    nodes = [{"localhost", 123}]
+    :ok = MockDiscovery.update(nodes)
+    send_health_check()
+
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+
+    assert :ok = MockCluster.add_node({"localhost", 345})
+
+    nodes = [{"localhost", 123}, {"localhost", 345}]
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+  end
+
+  test "It will remove a node" do
+    nodes = [{"localhost", 123}, {"localhost", 234}]
+    :ok = MockDiscovery.update(nodes)
+    send_health_check()
+
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+
+    assert :ok = MockCluster.remove_node({"localhost", 234})
+
+    nodes = [{"localhost", 123}]
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+  end
+
+  test "It won't remove all nodes" do
+    nodes = [{"localhost", 123}]
+    :ok = MockDiscovery.update(nodes)
+    send_health_check()
+
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+
+    assert :ok = MockCluster.remove_node({"localhost", 123})
+
+    verify_nodes_equal(nodes)
+    verify_nodes_present(nodes)
+  end
+
   defp verify_nodes_equal(nodes) do
     servers = MockCluster.servers()
     assert MapSet.equal?(MapSet.new(servers), MapSet.new(nodes))


### PR DESCRIPTION
If a node becomes unavailable for some reason, the current implementation requires waiting until the next health check is performed in order to change the nodes currently in the cluster. This change allows a node to be removed sooner and then added back when it becomes available again.